### PR TITLE
Run DocTest: Set Working Directory

### DIFF
--- a/Support/bin/run_doctest.rb
+++ b/Support/bin/run_doctest.rb
@@ -1,3 +1,5 @@
 #!/usr/bin/env ruby
 
-puts `rubydoctest --html --ignore-interactive "#{File.expand_path ENV['TM_FILEPATH']}"`
+filepath = File.expand_path ENV['TM_FILEPATH']
+Dir.chdir(ENV['TM_PROJECT_DIRECTORY'] || File.dirname(filepath))
+puts `rubydoctest --html --ignore-interactive "#{filepath}"`


### PR DESCRIPTION
Hi Dr Nic,

thank you for providing this very useful bundle. This pull request contains the following enhancement to the “Run DocTest” command:

The command  now set the working directory before it runs `rubydoctest`. The command uses
- the current project directory (`TM_PROJECT_DIRECTORY`), or if this directory is not set,
- it changes into the directory of the current file (`TM_FILEPATH`).

This changes makes sure that doctests that rely on the working directory now run correctly.

If I should change anything for this to get merged, please let me know.

Kind regards,
  René
